### PR TITLE
🔀 :: edit alert

### DIFF
--- a/Togather/Togather/Sources/Components/Home/PostForm.swift
+++ b/Togather/Togather/Sources/Components/Home/PostForm.swift
@@ -73,7 +73,7 @@ struct PostForm: View {
                     self.close = true
                 },
                 content: {
-                    PostDetail(
+                    PostDetailView(
                         showModal: $showDetail,
                         postID: postData.postID
                     )

--- a/Togather/Togather/Sources/Scene/MyView/View/myview ->/DeleteAccountView.swift
+++ b/Togather/Togather/Sources/Scene/MyView/View/myview ->/DeleteAccountView.swift
@@ -47,7 +47,7 @@ struct DeleteAccount: View {
                             .background(quitAccountVM.checkPassword() ? Color("RedStroke") : Color("TabBarStroke"))
                             .cornerRadius(6)
                             .alert("정말 계정을 삭제하시겠습니까?", isPresented: $showAlert) {
-                                Button("진행", role: .destructive) {
+                                Button("탈퇴", role: .destructive) {
                                     quitAccountVM.deleteAccount()
                                 }
                                 Button("취소", role: .cancel) { }

--- a/Togather/Togather/Sources/Scene/PostDetail/View/PostDetailView.swift
+++ b/Togather/Togather/Sources/Scene/PostDetail/View/PostDetailView.swift
@@ -2,9 +2,10 @@ import SwiftUI
 import SwiftUIFlowLayout
 import Kingfisher
 
-struct PostDetail: View {
+struct PostDetailView: View {
     @Binding var showModal: Bool
     @StateObject var postDetailViewModel = PostDetailViewModel()
+    @State private var showingAlert = false
     let postID: Int
     var body: some View {
         NavigationView {
@@ -133,8 +134,7 @@ struct PostDetail: View {
                                         backgroundColor: .error,
                                         cornerColor: .redDarken,
                                         action: {
-                                            postDetailViewModel.delete()
-                                            showModal.toggle()
+                                            showingAlert.toggle()
                                         }
                                     )
                                 }
@@ -146,6 +146,15 @@ struct PostDetail: View {
                 }
                 .padding(.horizontal, 16)
                 .padding(.bottom, 16)
+            }
+            .alert("게시물 삭제", isPresented: $showingAlert) {
+                Button("삭제", role: .destructive) {
+                    postDetailViewModel.delete()
+                    showModal.toggle()
+                }
+                Button("취소", role: .cancel) { }
+            } message: {
+                Text("정말로 삭제하시겠습니까?")
             }
             .redacted(reason: postDetailViewModel.showSkeleton ? .placeholder : [])
             .onAppear {
@@ -161,6 +170,6 @@ struct PostDetail: View {
 
 struct PostDetail_Previews: PreviewProvider {
     static var previews: some View {
-        PostDetail(showModal: .constant(true), postID: 1)
+        PostDetailView(showModal: .constant(true), postID: 1)
     }
 }


### PR DESCRIPTION
## Description
post detail 에서 게시물 삭제를 눌렀을 시 alert 가 화면에 나타나도록 하였다.

## Todo
- [x] 게시물 삭제 alert 추가
- [x] 탈퇴 alert 진행 -> 탈퇴

## UI
<img width="200" alt="스크린샷 2022-11-17 오후 12 27 43" src="https://user-images.githubusercontent.com/102791216/202347725-d751cce6-8011-4b8e-ac34-3ab6739510f8.png">
<img width="200" alt="스크린샷 2022-11-17 오후 12 30 42" src="https://user-images.githubusercontent.com/102791216/202348147-5d39ab79-8070-4ac9-93d2-20daa0735f42.png">
close #302 