### PR TITLE
🔀 :: (#317) HomeView.Tag -> SearchView 이동 기능 구현

### DIFF
--- a/Togather/Togather/Sources/Components/Home/TagSelectList.swift
+++ b/Togather/Togather/Sources/Components/Home/TagSelectList.swift
@@ -3,6 +3,8 @@ import Kingfisher
 
 struct TagSelectList: View {
     @Binding var tags: [Tags]
+    @Binding var bindingTag: String
+    var action: () -> Void
     var body: some View {
         VStack(spacing: 0) {
             ScrollView(.horizontal, showsIndicators: true) {
@@ -24,7 +26,8 @@ struct TagSelectList: View {
                                 .padding(.bottom, 9)
                         }
                         .onTapGesture {
-                            print(index.name)
+                            action()
+                            bindingTag = index.name
                         }
                     }
                 }
@@ -37,10 +40,10 @@ struct TagSelectList: View {
     }
 }
 
-struct TagSelectList_Previews: PreviewProvider {
-    static var previews: some View {
-        TagSelectList(
-            tags: .constant([Tags(name: "SpringBoot", imageUrl: "https://wouldyou1214.s3.amazonaws.com/SPRING.png"), Tags(name: "MySQL", imageUrl: "https://wouldyou1214.s3.amazonaws.com/MySQL.png"), Tags(name: "Node.js", imageUrl: "https://wouldyou1214.s3.amazonaws.com/Node.js.pn")])
-        )
-    }
-}
+// struct TagSelectList_Previews: PreviewProvider {
+//    static var previews: some View {
+//        TagSelectList(
+//            tags: .constant([Tags(name: "SpringBoot", imageUrl: "https://wouldyou1214.s3.amazonaws.com/SPRING.png"), Tags(name: "MySQL", imageUrl: "https://wouldyou1214.s3.amazonaws.com/MySQL.png"), Tags(name: "Node.js", imageUrl: "https://wouldyou1214.s3.amazonaws.com/Node.js.pn")])
+//        )
+//    }
+// }

--- a/Togather/Togather/Sources/Components/Search/SearchTagLabel.swift
+++ b/Togather/Togather/Sources/Components/Search/SearchTagLabel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SearchTagLabel: View {
-    let tag: String
+    @Binding var tag: String
     var body: some View {
         if tag != "" {
             Text(tag)
@@ -17,6 +17,6 @@ struct SearchTagLabel: View {
 
 struct SearchTagLabel_Previews: PreviewProvider {
     static var previews: some View {
-        SearchTagLabel(tag: "Swift")
+        SearchTagLabel(tag: .constant("swift"))
     }
 }

--- a/Togather/Togather/Sources/Scene/Home/View/HomeView.swift
+++ b/Togather/Togather/Sources/Scene/Home/View/HomeView.swift
@@ -6,6 +6,8 @@ import SwiftUIPullToRefresh
 
 struct HomeView: View {
     @State private var isClose: Bool = false
+    @Binding var tabBarIndex: TabIndex
+    @Binding var bindingTag: String
     @StateObject var homeViewModel = HomeViewModel()
     let animation = Animation
         .linear
@@ -23,7 +25,11 @@ struct HomeView: View {
                 } content: {
                     VStack(spacing: 0) {
                         TagSelectList(
-                            tags: $homeViewModel.tagList
+                            tags: $homeViewModel.tagList,
+                            bindingTag: $bindingTag,
+                            action: {
+                                tabBarIndex = .search
+                            }
                         )
                         ForEach(homeViewModel.postList, id: \.postID) { data in
                             PostForm(
@@ -56,8 +62,8 @@ struct HomeView: View {
     }
 }
 
-struct HomeView_Previews: PreviewProvider {
-    static var previews: some View {
-        HomeView()
-    }
-}
+// struct HomeView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        HomeView()
+//    }
+// }

--- a/Togather/Togather/Sources/Scene/Search/View/SearchView.swift
+++ b/Togather/Togather/Sources/Scene/Search/View/SearchView.swift
@@ -5,10 +5,10 @@ import Kingfisher
 
 struct SearchView: View {
     @State private var postList: [PostList] = []
-    @State private var tagBtnValue: String = ""
     @State private var stringTagList: [String] = []
     @State private var goTagList: Bool = false
     @State private var isClose: Bool = false
+    @Binding var tagBtnValue: String
     @StateObject var searchViewModel = SearchViewModel()
     var body: some View {
         GeometryReader { proxy in
@@ -26,7 +26,7 @@ struct SearchView: View {
                         )
                         .padding(.top, 11)
                         .padding(.bottom, 16)
-                        SearchTagLabel(tag: tagBtnValue)
+                        SearchTagLabel(tag: $tagBtnValue)
                             .padding(.bottom, 8)
                         PostButton(
                             title: "모든 태그 보기",
@@ -53,6 +53,11 @@ struct SearchView: View {
                             SearchTagListView(goBack: $goTagList, tagBtnValue: $tagBtnValue)
                         }
                     )
+                    .onChange(of: tagBtnValue) { _ in
+                        searchViewModel.title = ""
+                        searchViewModel.tag = tagBtnValue
+                        searchViewModel.postTag()
+                    }
                     ScrollView(showsIndicators: false) {
                         ForEach(searchViewModel.postList, id: \.postID) { data in
                             PostForm(
@@ -84,8 +89,8 @@ struct SearchView: View {
     }
 }
 
-struct SearchView_Previews: PreviewProvider {
-    static var previews: some View {
-        SearchView()
-    }
-}
+// struct SearchView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        SearchView()
+//    }
+// }

--- a/Togather/Togather/Sources/Scene/TabBar/View/ShowView.swift
+++ b/Togather/Togather/Sources/Scene/TabBar/View/ShowView.swift
@@ -1,26 +1,27 @@
 import SwiftUI
 struct ShowView: View {
-    let tabIndex: TabIndex
+    @Binding var tabIndex: TabIndex
+    @State private var bindingTag = ""
     var body: some View {
         VStack {
             switch tabIndex {
             case .home:
-                HomeView()
+                HomeView(tabBarIndex: $tabIndex, bindingTag: $bindingTag)
             case .chat:
                 ChatListView()
             case .write:
-                SearchView()
+                EmptyView()
             case .search:
-                SearchView()
+                SearchView(tagBtnValue: $bindingTag)
             case .mypage:
                 MyView()
             }
         }
     }
 }
-
-struct ShowView_Previews: PreviewProvider {
-    static var previews: some View {
-        ShowView(tabIndex: .home)
-    }
-}
+//
+// struct ShowView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ShowView(tabIndex: )
+//    }
+// }

--- a/Togather/Togather/Sources/Scene/TabBar/View/TabBarView.swift
+++ b/Togather/Togather/Sources/Scene/TabBar/View/TabBarView.swift
@@ -22,7 +22,7 @@ struct TabBarView: View {
             VStack(spacing: 0) {
                 Spacer()
                 ZStack(alignment: .bottom) {
-                    ShowView(tabIndex: tabIndex)
+                    ShowView(tabIndex: $tabIndex)
                         .padding(.top, getSafeAreaBot() ? 0 : 40)
                     ZStack {
                         VStack(spacing: 0) {


### PR DESCRIPTION
## Description
홈 뷰 위에 있는 태그를 눌러 서치뷰에 들어가 태그 검색으로 연동했다.

## Todo
- [x] 탭바 인덱스를 홈뷰에 바인딩 하기
- [x] 홈뷰 태그 값과 서치뷰 태그 값을 바인딩 해주기